### PR TITLE
Add support for SpotLED color devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ sender.send_data(
         ], 0, 0, spotled.Effect.NONE).serialize()
     )
 )
+
+if sender.color_depth != spotled.DisplayInfoResponse.COLOR_RGB:
+    exit()
+
+# if you have a color device, you can send RGB frames
+sender.send_data(
+    spotled.SendDataCommand([
+        spotled.AnimationDate([
+            spotled.FrameData(48, 12, spotled.gen_color_bitmap(
+                '................................................'
+                '..RRRR..GGGG..BBB...............................'
+                '..R..R..G.....B..B..............................'
+                '..RRR...G.GG..BBB...............................'
+                '..R..R..G..G..B..B..............................'
+                '..R..R..GGGG..BBBB..............................'
+                '................................................'
+                '................................................'
+                '................................................'
+                '................................................'
+                '................................................'
+                '................................................',
+                {'.': (0,0,0), 'R':(0,0,255), 'G': (0,255,0), 'B': (255,0,0)}
+            ), spotled.FrameData.COLOR_DEPTH_RGB)
+        ])
+    ])
+)
 ```
 
 See the `example_monika.py` file for an example animation and `example_pepsi.py` for an example


### PR DESCRIPTION
Thank you for creating this repo!

I have two SpotLED devices, one monochrome and the other color. I wanted to make an app that would provide better artist support than the default one. This repository gave me a great starting point for interfacing with these devices.

I was having trouble connecting with the color device, so I eventually had to decompile the SpotLED APK. I wanted to give back the knowledge I learned through this experience.

- The color depth you get back determines how frames are generated. 16 = monochrome (bitwise encoding), 255 = 3 byte color (BGR). There is also 49, 128 and 238, but I couldn't be bothered to look into these.
- The send_size=20 in _send_data_internal is the MTU - 3 of the device. 23 (send_size=20) is the default for Monochrome devices
- There is a missing response type = 254 (PauseSendingResponse), when send_size != MTU - 3